### PR TITLE
Negotiate client-assertion audience via discovery (OpenIddict 7)

### DIFF
--- a/lib/eryph/clientruntime/token_provider.rb
+++ b/lib/eryph/clientruntime/token_provider.rb
@@ -162,7 +162,8 @@ module Eryph
       end
 
       def request_new_token
-        client_assertion = create_client_assertion
+        audience, token_type = resolve_assertion_format
+        client_assertion = create_client_assertion(audience, token_type)
 
         request_body = {
           'grant_type' => 'client_credentials',
@@ -176,19 +177,77 @@ module Eryph
         parse_token_response(response)
       end
 
-      def create_client_assertion
+      # Discovery metadata flag advertised by OpenIddict 7+ eryph servers. When present with the
+      # value "issuer", the server requires the issuer as the client-assertion audience together
+      # with the "client-authentication+jwt" token type. Older servers omit it and expect the
+      # token endpoint as the audience.
+      CLIENT_ASSERTION_AUDIENCE_METADATA = 'eryph_client_assertion_audience'.freeze
+      CLIENT_ASSERTION_AUDIENCE_ISSUER = 'issuer'.freeze
+      CLIENT_AUTHENTICATION_JWT_TYPE = 'client-authentication+jwt'.freeze
+      LEGACY_CLIENT_ASSERTION_JWT_TYPE = 'JWT'.freeze
+
+      # Determine the client-assertion audience and token type the server expects by reading its
+      # discovery document. Fails closed: every eryph server serves a discovery document, so a
+      # failure to read it is a real error rather than a silent downgrade to a format the server
+      # would reject.
+      # @return [Array(String, String)] the audience and JWT "typ" header value
+      def resolve_assertion_format
+        metadata_url = @credentials.token_endpoint.sub(
+          %r{/connect/token/?\z}, '/.well-known/openid-configuration'
+        )
+
+        begin
+          response = create_faraday_connection.get(metadata_url) do |req|
+            req.headers['User-Agent'] = @http_config[:user_agent]
+          end
+        rescue Faraday::Error => e
+          raise TokenRequestError, "Could not read the identity provider's discovery document: #{e.message}"
+        end
+
+        unless response.success?
+          raise TokenRequestError, "Could not read the identity provider's discovery document (#{response.status})"
+        end
+
+        begin
+          discovery = JSON.parse(response.body)
+        rescue JSON::ParserError => e
+          raise TokenRequestError, "Could not parse the identity provider's discovery document: #{e.message}"
+        end
+
+        advertises_issuer =
+          discovery[CLIENT_ASSERTION_AUDIENCE_METADATA].to_s.casecmp(CLIENT_ASSERTION_AUDIENCE_ISSUER).zero?
+
+        if advertises_issuer
+          # The server explicitly requires the issuer as the audience, so a discovery document that
+          # advertises this but omits the issuer is invalid and must fail rather than downgrade to a
+          # legacy assertion the server would reject.
+          issuer = discovery['issuer']
+          if issuer.nil? || issuer.empty?
+            raise TokenRequestError,
+                  'The identity provider requires the issuer as the client-assertion audience, ' \
+                  'but its discovery document does not contain an issuer.'
+          end
+
+          [issuer, CLIENT_AUTHENTICATION_JWT_TYPE]
+        else
+          # Older servers don't advertise the flag and expect the token endpoint as the audience.
+          [@credentials.token_endpoint, LEGACY_CLIENT_ASSERTION_JWT_TYPE]
+        end
+      end
+
+      def create_client_assertion(audience, token_type)
         now = Time.now.to_i
 
         claims = {
           'iss' => @credentials.client_id,      # issuer
           'sub' => @credentials.client_id,      # subject
-          'aud' => @credentials.token_endpoint, # audience
+          'aud' => audience,                    # audience (issuer or token endpoint)
           'jti' => SecureRandom.uuid,           # JWT ID
           'iat' => now,                         # issued at
           'exp' => now + 300, # expires in 5 minutes
         }
 
-        JWT.encode(claims, @credentials.private_key, 'RS256')
+        JWT.encode(claims, @credentials.private_key, 'RS256', { 'typ' => token_type })
       end
 
       def make_token_request(request_body)

--- a/spec/support/webmock_setup.rb
+++ b/spec/support/webmock_setup.rb
@@ -10,6 +10,23 @@ WebMock.disable_net_connect!(
 
 # Helper methods for common HTTP mocks
 module WebMockHelpers
+  # Stub the OpenID Connect discovery document the token provider reads to negotiate the
+  # client-assertion audience format. By default it advertises the OpenIddict 7 issuer audience.
+  def stub_discovery(token_endpoint:, advertise_issuer_audience: true, issuer: nil)
+    metadata_url = token_endpoint.sub(%r{/connect/token/?\z}, '/.well-known/openid-configuration')
+    issuer ||= token_endpoint.sub(%r{/connect/token/?\z}, '')
+
+    body = { issuer: issuer }
+    body['eryph_client_assertion_audience'] = 'issuer' if advertise_issuer_audience
+
+    stub_request(:get, metadata_url)
+      .to_return(
+        status: 200,
+        body: body.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
   def stub_token_request(endpoint:, response: {})
     default_response = {
       access_token: 'test_access_token',

--- a/spec/unit/eryph/clientruntime/token_provider_spec.rb
+++ b/spec/unit/eryph/clientruntime/token_provider_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe Eryph::ClientRuntime::TokenProvider do
   let(:credentials) { build(:credentials) }
   let(:token_provider) { described_class.new(credentials) }
 
+  # The token provider reads the discovery document to negotiate the client-assertion audience
+  # before every token request. Stub it for the default credentials so unit tests can focus on
+  # the token request itself; individual examples override this stub to test the negotiation.
+  before { stub_discovery(token_endpoint: credentials.token_endpoint) }
+
   describe '#initialize' do
     it 'creates a token provider with credentials' do
       expect(token_provider.credentials).to eq(credentials)
@@ -221,8 +226,10 @@ RSpec.describe Eryph::ClientRuntime::TokenProvider do
   end
 
   describe '#create_client_assertion (private)' do
-    let(:assertion) { token_provider.send(:create_client_assertion) }
-    let(:decoded_claims) { JWT.decode(assertion, nil, false)[0] }
+    let(:assertion) { token_provider.send(:create_client_assertion, credentials.token_endpoint, 'JWT') }
+    let(:decoded) { JWT.decode(assertion, nil, false) }
+    let(:decoded_claims) { decoded[0] }
+    let(:decoded_header) { decoded[1] }
 
     it 'creates valid JWT with required claims' do
       expect(decoded_claims['iss']).to eq(credentials.client_id)
@@ -231,6 +238,16 @@ RSpec.describe Eryph::ClientRuntime::TokenProvider do
       expect(decoded_claims['jti']).to be_a(String)
       expect(decoded_claims['iat']).to be_a(Integer)
       expect(decoded_claims['exp']).to be_a(Integer)
+    end
+
+    it 'sets the requested token type in the JWT header' do
+      issuer_assertion = token_provider.send(
+        :create_client_assertion, 'https://test.eryph.local/identity', 'client-authentication+jwt'
+      )
+      header = JWT.decode(issuer_assertion, nil, false)[1]
+      expect(header['typ']).to eq('client-authentication+jwt')
+      claims = JWT.decode(issuer_assertion, nil, false)[0]
+      expect(claims['aud']).to eq('https://test.eryph.local/identity')
     end
 
     it 'sets expiration to 5 minutes from now' do
@@ -244,6 +261,49 @@ RSpec.describe Eryph::ClientRuntime::TokenProvider do
       expect do
         JWT.decode(assertion, public_key, true, { algorithm: 'RS256' })
       end.not_to raise_error
+    end
+  end
+
+  describe '#resolve_assertion_format (private)' do
+    let(:metadata_url) { 'https://test.eryph.local/identity/.well-known/openid-configuration' }
+
+    it 'uses the issuer audience when the server advertises the flag' do
+      stub_discovery(token_endpoint: credentials.token_endpoint, advertise_issuer_audience: true,
+                     issuer: 'https://test.eryph.local/identity')
+
+      audience, token_type = token_provider.send(:resolve_assertion_format)
+
+      expect(audience).to eq('https://test.eryph.local/identity')
+      expect(token_type).to eq('client-authentication+jwt')
+    end
+
+    it 'falls back to the token endpoint for legacy servers without the flag' do
+      stub_discovery(token_endpoint: credentials.token_endpoint, advertise_issuer_audience: false)
+
+      audience, token_type = token_provider.send(:resolve_assertion_format)
+
+      expect(audience).to eq(credentials.token_endpoint)
+      expect(token_type).to eq('JWT')
+    end
+
+    it 'fails closed when the issuer audience is required but the issuer is missing' do
+      stub_request(:get, metadata_url).to_return(
+        status: 200,
+        body: { 'eryph_client_assertion_audience' => 'issuer' }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+      expect do
+        token_provider.send(:resolve_assertion_format)
+      end.to raise_error(Eryph::ClientRuntime::TokenRequestError, /does not contain an issuer/)
+    end
+
+    it 'fails closed when the discovery document cannot be read' do
+      stub_request(:get, metadata_url).to_return(status: 404, body: 'not found')
+
+      expect do
+        token_provider.send(:resolve_assertion_format)
+      end.to raise_error(Eryph::ClientRuntime::TokenRequestError, /discovery document/)
     end
   end
 
@@ -440,7 +500,7 @@ RSpec.describe Eryph::ClientRuntime::TokenProvider do
 
       it 'propagates JWT errors' do
         expect do
-          token_provider.send(:create_client_assertion)
+          token_provider.send(:create_client_assertion, credentials.token_endpoint, 'JWT')
         end.to raise_error(JWT::EncodeError, 'Invalid key')
       end
     end


### PR DESCRIPTION
OpenIddict 7+ eryph servers require the **issuer** as the client-assertion audience plus the `client-authentication+jwt` token type; older servers expect the **token endpoint**. The token provider now reads the identity provider's discovery document and selects the format based on the `eryph_client_assertion_audience` flag (mirrors the .NET and go clients), so it works against both new and old servers. It **fails closed** if discovery can't be read rather than silently downgrading.

Added specs for the negotiation (issuer flag, legacy omission, fail-closed on missing issuer / unreachable discovery); existing token specs stub the discovery endpoint via a new `stub_discovery` helper.

Note: the ruby client is consumed by the vagrant-eryph plugin, which will need a gem bump once this is released.